### PR TITLE
Fix removing empty elements in array

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -222,11 +222,24 @@ function removeEmpty(obj) {
   return Object.keys(obj)
       .filter((k) => obj[k] != null)
       .reduce(
-          (newObj, k) =>
-                typeof obj[k] === 'object' ?
-                    {...newObj, [k]: removeEmpty(obj[k])} :
-                    {...newObj, [k]: obj[k]},
-          {}
+          (newObj, k) => {
+            if (typeof obj[k] === 'object' && !(obj[k] instanceof Array)) {
+              return {...newObj, [k]: removeEmpty(obj[k])};
+            } else if (typeof obj[k] === 'object' && (obj[k] instanceof Array)) {
+              var oldArray = obj[k]
+              var newArray = new Array();
+
+              for (var i in oldArray) {
+                newArray = [...newArray, removeEmpty(oldArray[i])];
+              }
+
+              newObj[k] = newArray;
+
+              return newObj;
+            } else {
+              return {...newObj, [k]: obj[k]};
+            }
+          }, {},
       );
 }
 


### PR DESCRIPTION

## Description
Json array is transformed in map when removing empty elements. 


## Related Issue
https://github.com/adobe/athena/issues/33

## How Has This Been Tested?

Set examples/performance/perfRun.yaml to
```
name: "apiKey"
version: "1.0"
description: ""
engine: autocannon
type: perfRun
config:
  url: https://api-gateway-qe-d-ue1.adobe.io/test
  connections: 2000
  duration: 30
  method: GET
  requests: # Array of objects.
    - headers:
        host: keepalive-with-upstream-test-stage-service-1.adobe.io
      method:
      path:
    - headers:
        host: baseline-performance-testing-stage-service-1.adobe.io
hooks:
  onInit:
  onDestroy:
  onRequest:
```
and run athena


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.